### PR TITLE
fix compilation error in TestRunner when using jvm target

### DIFF
--- a/std/haxe/unit/TestRunner.hx
+++ b/std/haxe/unit/TestRunner.hx
@@ -91,12 +91,12 @@ class TestRunner {
 
 		#elseif cs
 			cs.system.Console.Write(v);
-		#elseif java
+		#elseif (java && !jvm)
 			var str:String = v;
 			java.lang.System.out.print(str);
 		#elseif python
 			python.Lib.print(v);
-		#elseif (hl || lua || eval)
+		#elseif (hl || lua || eval || jvm)
 			Sys.print(Std.string(v));
 		#end
 	}


### PR DESCRIPTION
This fixes `hx3compat/1,0,3/std/haxe/unit/TestRunner.hx:96: characters 12-20 : [Ident:java.lang.String -> Unknown<0>] __java__` when using the jvm target.